### PR TITLE
Fix search failure due to missing positions on doc

### DIFF
--- a/lib/elasticlunr/dsl/query/bool_query.ex
+++ b/lib/elasticlunr/dsl/query/bool_query.ex
@@ -149,9 +149,11 @@ defmodule Elasticlunr.Dsl.BoolQuery do
 
             %{matched: matched, score: score, positions: positions} = ob
 
-            # credo:disable-for-lines:2
             positions =
-              Enum.reduce(doc.positions, positions, fn {field, tokens}, positions ->
+              doc
+              |> Map.get(:positions, %{})
+              # credo:disable-for-lines:2
+              |> Enum.reduce(positions, fn {field, tokens}, positions ->
                 p = Map.get(positions, field, [])
                 p = Enum.reduce(tokens, p, &(&2 ++ [&1]))
                 Map.put(positions, field, p)

--- a/test/dsl_test.exs
+++ b/test/dsl_test.exs
@@ -28,7 +28,16 @@ defmodule Elasticlunr.DslTest do
           content:
             "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas viverra enim non purus rutrum porta ut non urna. Nullam eu ante eget nisi laoreet pretium. Curabitur varius velit vel viverra facilisis. Pellentesque et condimentum mauris. Quisque faucibus varius interdum. Fusce cursus pretium tempus. Ut gravida tortor et mi dignissim sagittis. Aliquam ullamcorper dignissim arcu sollicitudin fermentum. Nunc elementum tortor ex, sit amet posuere lectus accumsan quis. Vivamus sit amet eros blandit, sagittis quam at, vulputate felis. Ut faucibus pretium feugiat. Fusce diam felis, euismod ac tellus id, blandit venenatis dolor. Nullam porttitor suscipit diam, a feugiat dui pharetra at."
         },
-        %{id: 3, content: "Lorem dog"}
+        %{id: 3, content: "Lorem dog"},
+        %{
+          id: 4,
+          content: "livebook is elixir's own jupyter. it's a very impressive impression."
+        },
+        %{
+          id: 5,
+          content:
+            "there are lots of contributors to the elixir project and many cool projects using elixir, ex. livebook, elixir_nx and so on"
+        }
       ])
 
     Map.put(context, :index, index)
@@ -39,7 +48,7 @@ defmodule Elasticlunr.DslTest do
       query = MatchAllQuery.new()
 
       assert result = MatchAllQuery.score(query, index, [])
-      assert Enum.count(result) == 3
+      assert Enum.count(result) == 5
 
       for %{score: score} <- result do
         assert score == 1
@@ -108,6 +117,10 @@ defmodule Elasticlunr.DslTest do
 
       refute BoolQuery.score(query, index, [])
              |> Enum.empty?()
+    end
+
+    test "check if document has positions before trying to acess it", %{index: index} do
+      assert Index.search(index, "me") |> Enum.empty?()
     end
   end
 


### PR DESCRIPTION
## Overview

The livebook sample in the project fails when I search for "me".

<img width="990" alt="Screen Shot 2021-11-06 at 1 27 17 PM" src="https://user-images.githubusercontent.com/13123868/140609575-6d12aef6-af03-40aa-b37c-3df9a97116df.png">

## TODO

- [x] Add error handling
- [x] GitHub Actions are all passing

## Testing

### How to test:

1. Click the "Run in Livebook" button
2. Run every code section

### What to test:

- [x] Searching for "me" or other variations works
