### PR TITLE
Change Query DSL To Map

### DIFF
--- a/lib/elasticlunr/dsl/query.ex
+++ b/lib/elasticlunr/dsl/query.ex
@@ -7,15 +7,13 @@ defmodule Elasticlunr.Dsl.Query do
             ref: Index.document_ref()
           })
 
-  @type options :: map()
-
-  @callback filter(module :: struct(), index :: Index.t(), options :: options()) :: list()
-  @callback score(module :: struct(), index :: Index.t(), options :: options()) :: score_results()
+  @callback filter(module :: struct(), index :: Index.t(), options :: keyword()) :: list()
+  @callback score(module :: struct(), index :: Index.t(), options :: keyword()) :: score_results()
   @callback rewrite(module :: struct(), index :: Index.t()) :: struct()
   @callback parse(options :: map(), query_options :: map(), repo :: module()) ::
               struct()
 
-  @spec split_root(map() | tuple()) :: {atom(), any()}
+  @spec split_root(map() | tuple()) :: {atom(), any()} | any()
   def split_root(root) when is_map(root) do
     [root_key] = Map.keys(root)
     value = Map.get(root, root_key)
@@ -24,6 +22,7 @@ defmodule Elasticlunr.Dsl.Query do
   end
 
   def split_root({_, _} = root), do: root
+  def split_root(root), do: root
 
   defmacro __using__(_) do
     quote location: :keep do

--- a/lib/elasticlunr/dsl/query.ex
+++ b/lib/elasticlunr/dsl/query.ex
@@ -7,16 +7,22 @@ defmodule Elasticlunr.Dsl.Query do
             ref: Index.document_ref()
           })
 
-  @type options :: any()
+  @type options :: map()
 
   @callback filter(module :: struct(), index :: Index.t(), options :: options()) :: list()
   @callback score(module :: struct(), index :: Index.t(), options :: options()) :: score_results()
   @callback rewrite(module :: struct(), index :: Index.t()) :: struct()
-  @callback parse(options :: keyword(), query_options :: keyword(), repo :: module()) ::
+  @callback parse(options :: map(), query_options :: map(), repo :: module()) ::
               struct()
 
-  @spec split_root(list() | tuple()) :: {atom(), any()}
-  def split_root(root) when is_list(root), do: hd(root)
+  @spec split_root(map() | tuple()) :: {atom(), any()}
+  def split_root(root) when is_map(root) do
+    [root_key] = Map.keys(root)
+    value = Map.get(root, root_key)
+
+    {root_key, value}
+  end
+
   def split_root({_, _} = root), do: root
 
   defmacro __using__(_) do

--- a/lib/elasticlunr/dsl/query/bool_query.ex
+++ b/lib/elasticlunr/dsl/query/bool_query.ex
@@ -235,7 +235,10 @@ defmodule Elasticlunr.Dsl.BoolQuery do
           should
           |> Enum.map(mapper)
 
-        Keyword.put([], :should, should)
+        Keyword.put(opts, :should, should)
+
+      should ->
+        Keyword.put(opts, :should, [mapper.(should)])
     end
   end
 
@@ -247,6 +250,9 @@ defmodule Elasticlunr.Dsl.BoolQuery do
       filter when is_list(filter) ->
         filter = Enum.map(filter, mapper)
         Keyword.put(opts, :filter, filter)
+
+      filter ->
+        Keyword.put(opts, :filter, [mapper.(filter)])
     end
   end
 
@@ -292,7 +298,7 @@ defmodule Elasticlunr.Dsl.BoolQuery do
         minimum_should_match = Map.get(options, "minimum_should_match")
         Keyword.put(opts, :minimum_should_match, minimum_should_match)
 
-      opts ->
+      _ ->
         opts
     end
   end

--- a/lib/elasticlunr/dsl/query/bool_query.ex
+++ b/lib/elasticlunr/dsl/query/bool_query.ex
@@ -212,7 +212,7 @@ defmodule Elasticlunr.Dsl.BoolQuery do
           repo.parse(key, value, query)
 
         _ ->
-          repo.parse(:match_all, [])
+          repo.parse("match_all", [])
       end
     end
 
@@ -226,7 +226,7 @@ defmodule Elasticlunr.Dsl.BoolQuery do
   end
 
   defp patch_options(opts, :should, options, mapper) do
-    case Keyword.get(options, :should) do
+    case Map.get(options, "should") do
       nil ->
         opts
 
@@ -240,7 +240,7 @@ defmodule Elasticlunr.Dsl.BoolQuery do
   end
 
   defp patch_options(opts, :filter, options, mapper) do
-    case Keyword.get(options, :filter) do
+    case Map.get(options, "filter") do
       nil ->
         opts
 
@@ -251,11 +251,11 @@ defmodule Elasticlunr.Dsl.BoolQuery do
   end
 
   defp patch_options(opts, :must, options, repo) do
-    case Keyword.get(options, :must) do
+    case Map.get(options, "must") do
       nil ->
         opts
 
-      must when is_list(must) ->
+      must when is_map(must) ->
         {key, options} = Query.split_root(must)
         must = repo.parse(key, options, must)
 
@@ -264,7 +264,7 @@ defmodule Elasticlunr.Dsl.BoolQuery do
   end
 
   defp patch_options(opts, :must_not, options, repo) do
-    case Keyword.get(options, :must_not) do
+    case Map.get(options, "must_not") do
       nil ->
         opts
 
@@ -279,7 +279,7 @@ defmodule Elasticlunr.Dsl.BoolQuery do
 
   defp patch_options(opts, :minimum_should_match, options) do
     options
-    |> Keyword.get(:minimum_should_match)
+    |> Map.get("minimum_should_match")
     |> case do
       nil ->
         opts
@@ -289,7 +289,7 @@ defmodule Elasticlunr.Dsl.BoolQuery do
     end
     |> case do
       true ->
-        minimum_should_match = Keyword.get(options, :minimum_should_match)
+        minimum_should_match = Map.get(options, "minimum_should_match")
         Keyword.put(opts, :minimum_should_match, minimum_should_match)
 
       opts ->

--- a/lib/elasticlunr/dsl/query/match_all_query.ex
+++ b/lib/elasticlunr/dsl/query/match_all_query.ex
@@ -11,7 +11,7 @@ defmodule Elasticlunr.Dsl.MatchAllQuery do
   @impl true
   def parse(options, _query_options, _repo) do
     options
-    |> Keyword.get(:boost, 1)
+    |> Map.get("boost", 1)
     |> __MODULE__.new()
   end
 

--- a/lib/elasticlunr/dsl/query/match_query.ex
+++ b/lib/elasticlunr/dsl/query/match_query.ex
@@ -1,8 +1,8 @@
 defmodule Elasticlunr.Dsl.MatchQuery do
   use Elasticlunr.Dsl.Query
 
-  alias Elasticlunr.{Index, Dsl.QueryRepository}
-  alias Elasticlunr.Dsl.{MatchAllQuery, QueryRepository, TermsQuery}
+  alias Elasticlunr.{Index}
+  alias Elasticlunr.Dsl.{MatchAllQuery, Query, QueryRepository, TermsQuery}
 
   defstruct ~w[expand field query boost fuzziness min_match operator]a
   @type t :: %__MODULE__{boost: integer()}
@@ -89,45 +89,17 @@ defmodule Elasticlunr.Dsl.MatchQuery do
   end
 
   @impl true
-  def parse(options, query_options, repo) do
-    fields =
-      options
-      |> Enum.filter(fn
-        {key, _val} when key in ~w[fuzziness operator] ->
-          false
-
-        _ ->
-          true
-      end)
-
-    fuzziness = Map.get(options, "fuzziness")
-    operator = Map.get(options, "operator", "or")
-    expand = Map.get(query_options, "expand", false)
-
+  def parse(options, _query_options, repo) do
     cond do
-      Enum.empty?(fields) ->
-        repo.parse("match_all", [], [])
+      Enum.empty?(options) ->
+        repo.parse("match_all", %{})
 
-      Enum.count(fields) > 1 ->
-        minimum_should_match =
-          case operator == "and" do
-            true ->
-              Enum.count(fields)
-
-            false ->
-              1
-          end
+      Enum.count(options) > 1 ->
+        minimum_should_match = Enum.count(options)
 
         should =
-          fields
-          |> Enum.map(fn {field, content} ->
-            match = %{
-              field => content,
-              "operator" => operator,
-              "fuzziness" => fuzziness
-            }
-
-            %{"match" => match, "expand" => expand}
+          Enum.map(options, fn {field, content} ->
+            %{"match" => %{field => content}}
           end)
 
         repo.parse("bool", %{
@@ -136,7 +108,11 @@ defmodule Elasticlunr.Dsl.MatchQuery do
         })
 
       true ->
-        [{field, content}] = fields
+        {field, params} = Query.split_root(options)
+
+        opts = to_match_params(params)
+
+        operator = Keyword.get(opts, :operator)
 
         minimum_should_match =
           case operator == "and" do
@@ -149,12 +125,28 @@ defmodule Elasticlunr.Dsl.MatchQuery do
 
         __MODULE__.new(
           field: field,
-          query: content,
-          fuzziness: fuzziness,
-          expand: expand,
           operator: operator,
+          query: Keyword.get(opts, :query),
+          expand: Keyword.get(opts, :expand),
+          fuzziness: Keyword.get(opts, :fuzziness),
           minimum_must_match: minimum_should_match
         )
     end
   end
+
+  defp to_match_params(params) when is_map(params) do
+    query = Map.get(params, "query")
+    fuzziness = Map.get(params, "fuzziness", 0)
+    operator = Map.get(params, "operator", "or")
+    expand = Map.get(params, "expand", false)
+
+    [
+      query: query,
+      expand: expand,
+      operator: operator,
+      fuzziness: fuzziness
+    ]
+  end
+
+  defp to_match_params(params), do: to_match_params(%{"query" => params})
 end

--- a/lib/elasticlunr/dsl/query_repository.ex
+++ b/lib/elasticlunr/dsl/query_repository.ex
@@ -1,4 +1,5 @@
 defmodule Elasticlunr.Dsl.QueryRepository do
+  alias Elasticlunr.Index
   alias Elasticlunr.Dsl.{BoolQuery, MatchAllQuery, MatchQuery, NotQuery, TermsQuery}
 
   def get("not"), do: NotQuery
@@ -8,24 +9,24 @@ defmodule Elasticlunr.Dsl.QueryRepository do
   def get("match_all"), do: MatchAllQuery
   def get(element), do: raise("Unknown query type #{element}")
 
-  def parse(module, options, query_options \\ [], repo \\ __MODULE__) do
+  @spec parse(binary(), map(), map(), module()) :: struct()
+  def parse(module, options, query_options \\ %{}, repo \\ __MODULE__) do
     module = get(module)
     module.parse(options, query_options, repo)
   end
 
+  @spec score(struct(), Index.t(), keyword()) :: list()
   def score(query, index, options \\ []) when is_struct(query) do
     query.__struct__.score(query, index, options)
   end
 
+  @spec filter(struct(), Index.t(), keyword()) :: list()
   def filter(query, index, options \\ []) when is_struct(query) do
     query.__struct__.filter(query, index, options)
   end
 
+  @spec rewrite(struct(), Index.t()) :: struct()
   def rewrite(query, index) when is_struct(query) do
     query.__struct__.rewrite(query, index)
-  end
-
-  def rewrite(query, index, options) when is_struct(query) do
-    query.__struct__.filter(query, index, options)
   end
 end

--- a/lib/elasticlunr/dsl/query_repository.ex
+++ b/lib/elasticlunr/dsl/query_repository.ex
@@ -1,11 +1,11 @@
 defmodule Elasticlunr.Dsl.QueryRepository do
   alias Elasticlunr.Dsl.{BoolQuery, MatchAllQuery, MatchQuery, NotQuery, TermsQuery}
 
-  def get(:not), do: NotQuery
-  def get(:bool), do: BoolQuery
-  def get(:match), do: MatchQuery
-  def get(:terms), do: TermsQuery
-  def get(:match_all), do: MatchAllQuery
+  def get("not"), do: NotQuery
+  def get("bool"), do: BoolQuery
+  def get("match"), do: MatchQuery
+  def get("terms"), do: TermsQuery
+  def get("match_all"), do: MatchAllQuery
   def get(element), do: raise("Unknown query type #{element}")
 
   def parse(module, options, query_options \\ [], repo \\ __MODULE__) do

--- a/test/dsl_test.exs
+++ b/test/dsl_test.exs
@@ -19,23 +19,23 @@ defmodule Elasticlunr.DslTest do
     pipeline = Pipeline.new([callback])
 
     index =
-      [fields: [content: [pipeline: pipeline]]]
-      |> Index.new()
+      Index.new()
+      |> Index.add_field("content", pipeline: pipeline)
       |> Index.add_documents([
-        %{id: 1, content: "The quick fox jumped over the lazy dog"},
+        %{"id" => 1, "content" => "The quick fox jumped over the lazy dog"},
         %{
-          id: 2,
-          content:
+          "id" => 2,
+          "content" =>
             "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas viverra enim non purus rutrum porta ut non urna. Nullam eu ante eget nisi laoreet pretium. Curabitur varius velit vel viverra facilisis. Pellentesque et condimentum mauris. Quisque faucibus varius interdum. Fusce cursus pretium tempus. Ut gravida tortor et mi dignissim sagittis. Aliquam ullamcorper dignissim arcu sollicitudin fermentum. Nunc elementum tortor ex, sit amet posuere lectus accumsan quis. Vivamus sit amet eros blandit, sagittis quam at, vulputate felis. Ut faucibus pretium feugiat. Fusce diam felis, euismod ac tellus id, blandit venenatis dolor. Nullam porttitor suscipit diam, a feugiat dui pharetra at."
         },
-        %{id: 3, content: "Lorem dog"},
+        %{"id" => 3, "content" => "Lorem dog"},
         %{
-          id: 4,
-          content: "livebook is elixir's own jupyter. it's a very impressive impression."
+          "id" => 4,
+          "content" => "livebook is elixir's own jupyter. it's a very impressive impression."
         },
         %{
-          id: 5,
-          content:
+          "id" => 5,
+          "content" =>
             "there are lots of contributors to the elixir project and many cool projects using elixir, ex. livebook, elixir_nx and so on"
         }
       ])
@@ -60,7 +60,7 @@ defmodule Elasticlunr.DslTest do
     test "performs base functionality", %{index: index} do
       query =
         TermsQuery.new(
-          field: :content,
+          field: "content",
           terms: ["fox"]
         )
 
@@ -72,13 +72,13 @@ defmodule Elasticlunr.DslTest do
     test "boost", %{index: index} do
       non_boost_query =
         TermsQuery.new(
-          field: :content,
+          field: "content",
           terms: ["fox"]
         )
 
       boost_query =
         TermsQuery.new(
-          field: :content,
+          field: "content",
           terms: ["fox"],
           boost: 2
         )
@@ -96,9 +96,9 @@ defmodule Elasticlunr.DslTest do
     test "filters via must functionality", %{index: index} do
       query =
         BoolQuery.new(
-          must: TermsQuery.new(field: :content, terms: ["lorem"]),
+          must: TermsQuery.new(field: "content", terms: ["lorem"]),
           should: [
-            TermsQuery.new(field: :content, terms: ["dog"])
+            TermsQuery.new(field: "content", terms: ["dog"])
           ]
         )
 
@@ -108,10 +108,10 @@ defmodule Elasticlunr.DslTest do
     test "filters via must_not functionality", %{index: index} do
       query =
         BoolQuery.new(
-          must: TermsQuery.new(field: :content, terms: ["lorem"]),
-          must_not: TermsQuery.new(field: :content, terms: ["ipsum"]),
+          must: TermsQuery.new(field: "content", terms: ["lorem"]),
+          must_not: TermsQuery.new(field: "content", terms: ["ipsum"]),
           should: [
-            TermsQuery.new(field: :content, terms: ["dog"])
+            TermsQuery.new(field: "content", terms: ["dog"])
           ]
         )
 
@@ -126,7 +126,7 @@ defmodule Elasticlunr.DslTest do
 
   describe "match" do
     test "performs base functionality", %{index: index} do
-      query = MatchQuery.new(field: :content, query: "brown fox")
+      query = MatchQuery.new(field: "content", query: "brown fox")
 
       assert results = MatchQuery.score(query, index, [])
       assert Enum.count(results) == 1
@@ -134,7 +134,7 @@ defmodule Elasticlunr.DslTest do
     end
 
     test "honours minimum_should_match", %{index: index} do
-      query = MatchQuery.new(field: :content, query: "brown fox quick", minimum_should_match: 2)
+      query = MatchQuery.new(field: "content", query: "brown fox quick", minimum_should_match: 2)
 
       assert results = MatchQuery.score(query, index, [])
       assert Enum.count(results) == 1
@@ -144,7 +144,7 @@ defmodule Elasticlunr.DslTest do
     test "honours and operator", %{index: index} do
       query =
         MatchQuery.new(
-          field: :content,
+          field: "content",
           query: "fox quick",
           operator: "and"
         )

--- a/test/elasticlunr_test.exs
+++ b/test/elasticlunr_test.exs
@@ -7,8 +7,11 @@ defmodule ElasticlunrTest do
     test "creates a new index" do
       assert %Index{name: "index_1", fields: %{}} = Elasticlunr.index("index_1")
 
-      assert %Index{name: "index_2", fields: %{title: _, body: _}} =
-               Elasticlunr.index("index_2", fields: ~w[title body]a)
+      assert %Index{name: "index_2", fields: %{"title" => _, "body" => _}} =
+               "index_2"
+               |> Elasticlunr.index()
+               |> Index.add_field("body")
+               |> Index.add_field("title")
     end
 
     test "retrieves existing index instead of creating a new one" do


### PR DESCRIPTION
## Overview

The initial design of the DSL `parse` function expects a keyword. But this initial decision is not optimal for situations where one decides to pass a JSON received from an API directly to the `Index.search(...)`. And one of the goals for the project is to provide a web layer that accepts these queries and passes them to the search function of the corresponding index.

And these changes contain the foundation for adding documents with nested attributes and being able to search by these nested attributes.

## TODO

- [x] Add error handling
- [x] Add Loom video demo
- [x] GitHub Actions are all passing

## Testing

### How to test:

_Write down steps needed, if any, to test your PR locally in case the preview links do not work_

1. Create an index
2. Add some documents to the index
3. Confirm that search works when given a map for query

### What to test:

- [x] One can only add fields whose name is a binary/string
- [x] When given a map, the parse function works correctly
- [x] Fields are added explicitly by calling `Index.add_field` on an index
