### PR TITLE
Improve Public API

### DIFF
--- a/lib/elasticlunr.ex
+++ b/lib/elasticlunr.ex
@@ -3,9 +3,11 @@ defmodule Elasticlunr do
   Documentation for `Elasticlunr`.
   """
 
+  @type index_name :: atom() | binary()
+
   alias Elasticlunr.{Index, IndexManager, Pipeline}
 
-  @spec index(atom() | binary(), keyword()) :: Index.t() | :not_running
+  @spec index(index_name(), keyword()) :: Index.t() | :not_running
   def index(name, opts \\ []) do
     with opts <- with_default_pipeline([name: name] ++ opts),
          index <- Index.new(opts),
@@ -18,9 +20,13 @@ defmodule Elasticlunr do
     end
   end
 
-  @spec update_index(Index.t()) :: Index.t() | :not_running
-  def update_index(%Index{} = index) do
-    IndexManager.update_index(index)
+  @spec update_index(index_name(), function()) :: Index.t() | :not_running
+  def update_index(name, callback) do
+    with %Index{} = index <- IndexManager.get(name),
+         index <- callback.(index),
+         %Index{} = index <- IndexManager.update_index(index) do
+      index
+    end
   end
 
   @spec default_pipeline() :: Pipeline.t()

--- a/lib/elasticlunr/manager/index_manager.ex
+++ b/lib/elasticlunr/manager/index_manager.ex
@@ -20,6 +20,7 @@ defmodule Elasticlunr.IndexManager do
     {:ok, index}
   end
 
+  @spec update_index(Elasticlunr.Index.t()) :: Index.t() | :not_running
   def update_index(%Index{name: name} = index) do
     case loaded?(name) do
       true ->


### PR DESCRIPTION
## Overview

Improve the public API on the `Elasticlunr` module. This module contains the functions needed to fiddle with indexes monitored by the supervisor.

## TODO

- [x] Update `Elasticlunr` to provide a function to update an index.
- [x] Improve typespecs
- [x] GitHub Actions are all passing

### What to test:

- [x] `Elasticlunr.update_index/2` works as expected
